### PR TITLE
fix "cant find res://" and update version

### DIFF
--- a/addons/SyndiBox/syndibox.gd
+++ b/addons/SyndiBox/syndibox.gd
@@ -1,7 +1,7 @@
 """
 #########################################################################
 ################### SyndiBox Text Engine for Godot ######################
-########################### Version 1.5.0 ###############################
+########################### Version 1.5.1 ###############################
 #########################################################################
 
 'A text engine with everything you want and need will cost
@@ -150,7 +150,10 @@ func _ready(): # Called when ready.
 	add_child(prof_label)
 	# Set these variables to their appropriate exports.
 	cur_string = strings[cur_set]
-	snd_stream = load(TEXT_VOICE)
+	if TEXT_VOICE:
+		snd_stream = load(TEXT_VOICE)
+	else:
+		snd_stream = null
 	if !FONT:
 		FONT = load("res://addons/SyndiBox/Assets/TextDefault.tres")
 	if FONT is String:
@@ -747,7 +750,10 @@ func print_dialog(string): # Called on draw
 		# Set up profile
 		if !text_hide:
 			if CHARACTER_PROFILE is String:
-				def_profile = load(CHARACTER_PROFILE)
+				if CHARACTER_PROFILE:
+					def_profile = load(CHARACTER_PROFILE)
+				else:
+					CHARACTER_PROFILE = null
 			else:
 				def_profile = CHARACTER_PROFILE
 			if CHARACTER_PROFILE != null:


### PR DESCRIPTION
there is an issue occurring when the user does not include a player profile or name. this causes 25 errors which can be quite annoying.
I found a fix to this which you can find in line 753 and line 153.
i also changed the version from 1.5.0 to 1.5.1 cause i kept thinking i was running an old version XD!
Thanks,
Ron0Studios