### PR TITLE
Remove unsupported static typing on signals

### DIFF
--- a/addons/SyndiBox/syndibox.gd
+++ b/addons/SyndiBox/syndibox.gd
@@ -117,8 +117,8 @@ onready var hide_timer # fuck
 onready var custom = Node.new() # Filler for custom effect script
 signal text_finished #emitted when dialog is finished
 signal text_started  # emitted when dialog starts
-signal section_started(cur_section : int) # emitted when a part of the dialog has started
-signal section_finished(cur_section : int) # emitted when a part of the dialog is finished
+signal section_started(cur_section) # emitted when a part of the dialog has started
+signal section_finished(cur_section) # emitted when a part of the dialog is finished
 ################################## END ##################################
 
 ##################
@@ -178,18 +178,18 @@ func _ready(): # Called when ready.
 	timer = Timer.new()
 	timer.set_wait_time(speed)
 	add_child(timer)
-	
+
 	# Make an audio stream player and set stream to character's dialog voice.
 	voice = AudioStreamPlayer.new()
 	voice.set_stream(snd_stream)
 	voice.volume_db = -6
 	add_child(voice)
-	
+
 	tween = Tween.new()
 	tween_trans = tween.TRANS_LINEAR
 	tween_ease = tween.EASE_IN_OUT
 	add_child(tween)
-	
+
 	if !Engine.editor_hint && visible:
 		print_dialog(cur_string)
 #	else:
@@ -915,7 +915,7 @@ func _input(event): # Called on input
 				# Call our print_dialog function.
 				if visible:
 					print_dialog(cur_string)
-					
+
 				emit_signal("section_started", cur_set)
 				emit_signal("section finished", cur_set - 1)
 
@@ -927,7 +927,7 @@ func _physics_process(delta): # Called every step
 		step_pause >= 120 &&
 		visible
 	):
-		
+
 		# If there are no more strings in the dialog...
 		if cur_set >= strings.size() - 1:
 			# Hide the textbox.


### PR DESCRIPTION
While installing the current version of SyndiBox through the Godot Asset Library, I noticed I was unable to activate the plugin due to a syntax error.

It looks like signals [don't yet support static typing](https://github.com/godotengine/godot/issues/26045) so I removed the static typing that was preventing the plugin from activating.