### PR TITLE
Fixed emitting wrong signal for section_finished

### DIFF
--- a/addons/SyndiBox/syndibox.gd
+++ b/addons/SyndiBox/syndibox.gd
@@ -825,7 +825,7 @@ func _input(event): # Called on input
 					print_dialog(cur_string)
 
 				emit_signal("section_started", cur_set)
-				emit_signal("section finished", cur_set - 1)
+				emit_signal("section_finished", cur_set - 1)
 
 func _physics_process(delta): # Called every step
 	# If 3 seconds have passed for auto advancement...


### PR DESCRIPTION
Previously, this bit of code would emit "section finished" instead of "section_finished".
This merge request fixes this typo.