### PR TITLE
Fix for [BUG] Instant Print off tag does not shut off Instant Print #36

### DIFF
--- a/addons/SyndiBox/syndibox.gd
+++ b/addons/SyndiBox/syndibox.gd
@@ -557,6 +557,14 @@ func speed_check(string):
 				"[*r]": # Reset
 					INSTANT_PRINT = def_print
 					speed = def_speed
+		else:
+			match emph:
+				"[*n]": # Non-Instant
+					INSTANT_PRINT = false
+					speed = def_speed
+				"[*r]": # Reset
+					INSTANT_PRINT = def_print
+					speed = def_speed
 	return string
 
 # Positional Effects #


### PR DESCRIPTION
Updated speed_check to properly check for 'end of instant print' tags.

The speed_check would not check for 'end of instant print' tags after it entered 'instant print' mode. This fix adds an else clause to only check for those tags during an instant print.